### PR TITLE
chore: Update repository props in package files

### DIFF
--- a/packages/koa-access/package.json
+++ b/packages/koa-access/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uswitch/koa-access.git"
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-access"
   },
   "author": "Dom Charlesworth <dominic.charlesworth@uswitch.com>",
   "devDependencies": {

--- a/packages/koa-prometheus/package.json
+++ b/packages/koa-prometheus/package.json
@@ -18,6 +18,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-prometheus"
+  },
   "watch": {
     "build": "src/*"
   },

--- a/packages/koa-signal/package.json
+++ b/packages/koa-signal/package.json
@@ -19,6 +19,11 @@
   "publishConfig": {
     "access": "public"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-signal"
+  },
   "watch": {
     "build": "src/*"
   },

--- a/packages/koa-timeout/package.json
+++ b/packages/koa-timeout/package.json
@@ -11,7 +11,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uswitch/koa-timeout.git"
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-timeout"
   },
   "author": "Dom Charlesworth <dgc336@gmail.com> (http://domcharlesworth.co.uk/)",
   "license": "MIT",

--- a/packages/koa-tracer/package.json
+++ b/packages/koa-tracer/package.json
@@ -22,7 +22,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uswitch/koa-tracer.git"
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-tracer"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/koa-zipkin/package.json
+++ b/packages/koa-zipkin/package.json
@@ -21,7 +21,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/uswitch/koa-core.git"
+    "url": "git+https://github.com/uswitch/koa-core.git",
+    "directory": "packages/koa-zipkin"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
This PR updates the repository fields in the package files to align with the current repo structure. 

This will make PRs from Dependabot in repos that use the _koa-*_ packages more helpful since it can point to commits in the right repo and directory.