### PR TITLE
🤐  Allow creating a Tracer object with async support in its ContextCLS

### DIFF
--- a/packages/koa-zipkin/koa-zipkin.js
+++ b/packages/koa-zipkin/koa-zipkin.js
@@ -9,9 +9,9 @@ const { NODE_DEBUG } = process.env
 const debug = msg => NODE_DEBUG && console.log(`koa-zipkin | ${msg}`)
 
 /**
- * 
- * @param {string} localServiceName 
- * @param {object} logger 
+ * Creates a Zipkin Tracer, using ContextCLS and BatchRecorder
+ * @param {string} localServiceName - The local name of this service
+ * @param {object} logger - An instantiated Logger object
  * @param {boolean} allowAsync - Required for compatability with the ContextCLS
  * library if your code uses promises or async/await. Note there are known
  * performance issues with Node < 16.3.0.

--- a/packages/koa-zipkin/koa-zipkin.js
+++ b/packages/koa-zipkin/koa-zipkin.js
@@ -8,9 +8,19 @@ import wrapTags from './koa-wrap-fetch'
 const { NODE_DEBUG } = process.env
 const debug = msg => NODE_DEBUG && console.log(`koa-zipkin | ${msg}`)
 
-export const Tracer = (localServiceName, logger) => new T({
+/**
+ * 
+ * @param {string} localServiceName 
+ * @param {object} logger 
+ * @param {boolean} allowAsync - Required for compatability with the ContextCLS
+ * library if your code uses promises or async/await. Note there are known
+ * performance issues with Node < 16.3.0.
+ * See https://github.com/openzipkin/zipkin-js/tree/master/packages/zipkin-context-cls#a-note-on-cls-context-and-promises
+ * @returns {object}
+ */
+export const Tracer = (localServiceName, logger, allowAsync = false) => new T({
   localServiceName,
-  ctxImpl: new Context('zipkin'),
+  ctxImpl: new Context('zipkin', allowAsync),
   recorder: new BatchRecorder({ logger })
 })
 

--- a/packages/koa-zipkin/readme.md
+++ b/packages/koa-zipkin/readme.md
@@ -110,3 +110,15 @@ const tracer = Tracer(APP_NAME, Logger({ local: NODE_ENV === 'development' }))
 export const zipkin = middleware({ tracer })
 export const zipkinFetch = fetch({ local: APP_NAME, client, tracer })
 ```
+
+### Enabling experimental ContextCLS feature to support tracing through code with promises / async / await
+
+Please see https://github.com/openzipkin/zipkin-js/tree/master/packages/zipkin-context-cls#a-note-on-cls-context-and-promises, and note that by default - asynchronous code is not supported by ContextCLS. If you see fetches appearing in Zipkin with a different Trace ID, this could be the reason..
+
+To enable this, create the Tracer object as follows:
+
+```js
+Tracer(APP_NAME, logger, true)
+```
+
+**Please also note there are known performance implications of enabling this feature on Node versions below 16.3.0**


### PR DESCRIPTION
This experimental feature is needed to allow tracing through code that uses promises, and async/await. Without this option enabled, async calls to the wrapped fetch for example will all have different trace IDs and appear separately in Zipkin.

Have tested this in broadband-aggregator and broadband-product-availability, which both use Node 16.14.0 - and the issue is fixed. This change should have no effect to people who don't want to enable the option.