### PR TITLE
🚦 Replacing chalk with picocolors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,17 +39,17 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
-      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
+      "version": "7.20.13",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.20.13.tgz",
+      "integrity": "sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==",
       "requires": {
-        "regenerator-runtime": "^0.13.4"
+        "regenerator-runtime": "^0.13.11"
       },
       "dependencies": {
         "regenerator-runtime": {
-          "version": "0.13.9",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-          "integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
+          "version": "0.13.11",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+          "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
         }
       }
     },
@@ -1739,51 +1739,51 @@
       "dev": true
     },
     "@uswitch/koa-access": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-access/-/koa-access-2.9.0.tgz",
-      "integrity": "sha512-fhGJsXh9XZpZfRckQ4id1RZiKsR6EGWh4Z5zLtGvMyRH7TjbVggDiYRSvptscHO87uPypsXJa6Q3I2E1mT+N1Q==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-access/-/koa-access-2.9.2.tgz",
+      "integrity": "sha512-AyHIEzHL5LDcAnxabtvwybvb13sq5ESbcl8JQkPFb1urk9EPeZV6nirSqGq2BMnlfVIezladgSkdnHRLVOuyoA==",
       "requires": {
         "on-finished": "^2.3.0"
       }
     },
     "@uswitch/koa-cookie": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-cookie/-/koa-cookie-1.4.0.tgz",
-      "integrity": "sha512-648m40COswFoSi81o1P0ht2Ld2z4PR5I/0s8gZX0+/Nyv1XCCB3u+4tL+nx5ecnP9LyiWb64jLn7yumk7zBuyw=="
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-cookie/-/koa-cookie-1.4.2.tgz",
+      "integrity": "sha512-GyXaTD01hqkoa6a3QySkdK/g7GUrWbqgFIzFsCs8YcbdgRnt/fmEVXQLGCZ6Fi++RVBO0eluI3QCBDpm02iI2A=="
     },
     "@uswitch/koa-prometheus": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-prometheus/-/koa-prometheus-0.7.1.tgz",
-      "integrity": "sha512-9RBfDcpUZPniY6+rko3zY+4fHXvPmvOM+IlWZn/m5o9dmadBhsX5y1jY2CdGC3OY0WGxhLht1UBrR0drny+DOw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-prometheus/-/koa-prometheus-0.7.3.tgz",
+      "integrity": "sha512-aXr1+gnmf03pYkOOGseZLRtpRZrRnpHR+cKdgHzN5ISe70zRJfgmnOQxZ6b4uXuE0zQurnUyx1M8KjTJ8aNzCA==",
       "requires": {
         "metrics": "^0.1.21",
         "prom-client": "^11.5.3",
-        "prometheus-gc-stats": "^0.6.2"
+        "prometheus-gc-stats": "^0.6.3"
       }
     },
     "@uswitch/koa-signal": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-signal/-/koa-signal-1.10.0.tgz",
-      "integrity": "sha512-atHvvtWm9BV0AzDFIFJDMmWkPQP5xnrAvJ5N8D9FYs5PnCbjFY60126Z9XYVvGLnKpdsPTw6K+blztJNUvvmDw==",
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-signal/-/koa-signal-1.10.2.tgz",
+      "integrity": "sha512-7uAw8sTboDZVwPj0P1T0WSzEwuSRezXhjRiBdRThlPh7Ypkh7F17TsPcq1z65X6zxF3Up+rQFdPqSSNN8kMl3Q==",
       "requires": {
         "chalk": "^2.4.1",
         "json-stringify-safe": "^5.0.1"
       }
     },
     "@uswitch/koa-timeout": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-timeout/-/koa-timeout-1.6.0.tgz",
-      "integrity": "sha512-J3PHSXwbvLtaGOpf3yjN7QRHeQNc3X/lzif4Umoomm9HtvbVLBIY+3+ItOdCxGyPD0RfRcmZHe54VSq5G6vuhg=="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-timeout/-/koa-timeout-1.6.2.tgz",
+      "integrity": "sha512-yWAFfDU0xZLG072+ltdYqOvinCvhLRvCA4zNrnqXlnquTFT70gPrVtq0fXi8wMXLZp1x1Wotd2WDE0DQqTrlXw=="
     },
     "@uswitch/koa-tracer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-tracer/-/koa-tracer-1.7.0.tgz",
-      "integrity": "sha512-hEFkmkcMGN/88aAyKUYmld6kLyeykxeRGIfh4XRFFK/3R01mMvZYiHt7Qe4yb1TJOneiQyH80K+kPYzjDomgXA=="
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-tracer/-/koa-tracer-1.7.2.tgz",
+      "integrity": "sha512-jUWHRht2OhsNtt97EtdsgAyRDYojS4Oho7Miab2BosPW4+MYSc1lWC+c5iJIwL+dJxLdtQOAKRIuz8CCZSD3PA=="
     },
     "@uswitch/koa-zipkin": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@uswitch/koa-zipkin/-/koa-zipkin-1.11.2.tgz",
-      "integrity": "sha512-4TLNL7qw/ZIYog3Z9T4f8GwGW0pj6OeHiFezTwC+XPRBQYLn0QgoEc6Jp9c8IlqnU1Wjg47kHJg92yTYH/kjVQ==",
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/@uswitch/koa-zipkin/-/koa-zipkin-1.11.4.tgz",
+      "integrity": "sha512-yaBg10eUN27ZJGm199AZqrzOzUO2xSlruy5wtwxItAwi5KfQ/yuzxl+qtAuhkN9nyB46ioXs5hGSg79W7QOo9A==",
       "requires": {
         "node-fetch": "^2.6.7",
         "zipkin": "^0.22.0",
@@ -1794,9 +1794,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+          "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
           "requires": {
             "whatwg-url": "^5.0.0"
           }
@@ -9989,9 +9989,9 @@
       }
     },
     "prometheus-gc-stats": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.3.tgz",
-      "integrity": "sha512-vCX+HZ1jZHkha25r5dAcRSNjue+K3Hn0B33EcZl7y3hgp3o1YsQ4Y3x7oJWKvDdbelFIL0McsXGmRg3zBrmq+g==",
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/prometheus-gc-stats/-/prometheus-gc-stats-0.6.4.tgz",
+      "integrity": "sha512-HtxtDYRurj7gZS9AqjcfEAldf2e053mh+XW//OjifRxr6Y/aLx8y7ETwWesnJ9DaufvAMyqUUQJUzhB9jLc6vg==",
       "requires": {
         "gc-stats": "^1.4.0",
         "optional": "^0.1.3"

--- a/packages/koa-signal/package-lock.json
+++ b/packages/koa-signal/package-lock.json
@@ -1419,6 +1419,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2604,6 +2605,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -2744,6 +2746,7 @@
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
       "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.1"
       }
@@ -2751,7 +2754,8 @@
     "color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
-      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok="
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
+      "dev": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -3190,7 +3194,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.11.1",
@@ -4629,7 +4634,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -8570,6 +8576,11 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
+    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -10056,6 +10067,7 @@
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/packages/koa-signal/package.json
+++ b/packages/koa-signal/package.json
@@ -36,8 +36,8 @@
     }
   },
   "dependencies": {
-    "chalk": "^2.4.1",
-    "json-stringify-safe": "^5.0.1"
+    "json-stringify-safe": "^5.0.1",
+    "picocolors": "^1.0.0"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",

--- a/packages/koa-signal/src/components/error.js
+++ b/packages/koa-signal/src/components/error.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import pc from 'picocolors'
 
 /* Config and then passed Koa ctx & msg */
 export default (config = {}) => (ctx, error = {}) => {
@@ -18,6 +18,6 @@ export default (config = {}) => (ctx, error = {}) => {
     : tail
 
   return displayStackTrace
-    ? [ head, ...stack.map(it => chalk[color](it)).map(i => i.replace(/^/, '\n')) ]
+    ? [ head, ...stack.map(it => pc[color](it)).map(i => i.replace(/^/, '\n')) ]
     : head
 }

--- a/packages/koa-signal/src/components/message.js
+++ b/packages/koa-signal/src/components/message.js
@@ -1,4 +1,4 @@
-import { bold } from 'chalk'
+import { bold } from 'picocolors'
 import format from '../helper/format'
 
 const isObject = obj => obj === Object(obj)

--- a/packages/koa-signal/src/components/summary.js
+++ b/packages/koa-signal/src/components/summary.js
@@ -1,4 +1,4 @@
-import { bold, red } from 'chalk'
+import { bold, red } from 'picocolors'
 
 import format from '../helper/format'
 import flatten from '../helper/flatten'

--- a/packages/koa-signal/src/helper/format.js
+++ b/packages/koa-signal/src/helper/format.js
@@ -1,4 +1,4 @@
-import chalk from 'chalk'
+import pc from 'picocolors'
 
 export default (config, text) => {
   if (!text) return
@@ -13,9 +13,9 @@ export default (config, text) => {
   const padF = alignment === 'left' ? 'padEnd' : 'padStart'
   const displayText = minimumWidth ? text[padF](minimumWidth) : text
 
-  const chalkF = Array.isArray(color)
-    ? color.reduce((acc, it) => acc[it], chalk)
-    : chalk[color] || (i => i)
+  const colorF = Array.isArray(color)
+    ? color.reduce((acc, it) => (msg) => acc(pc[it](msg)), pc.reset)
+    : pc[color] || (i => i)
 
-  return chalkF(displayFormat.replace('%s', displayText))
+  return colorF(displayFormat.replace('%s', displayText))
 }

--- a/packages/koa-signal/src/helper/text-modifier.js
+++ b/packages/koa-signal/src/helper/text-modifier.js
@@ -1,7 +1,7 @@
-import chalk from 'chalk'
+import pc from 'picocolors'
 
 export default (config = {}, text) => [
   config.uppercase && ((s = '') => s.toUpperCase()),
-  config.underline && ((s = '') => chalk.underline(s)),
-  config.italic && ((s = '') => chalk.italic(s))
+  config.underline && ((s = '') => pc.underline(s)),
+  config.italic && ((s = '') => pc.italic(s))
 ].reduce((acc, it) => it ? it(acc) : acc, text)

--- a/packages/koa-signal/src/koa-signal.defaults.json
+++ b/packages/koa-signal/src/koa-signal.defaults.json
@@ -34,7 +34,7 @@
 
     "trace": {
       "badge": "⚡️",
-      "labelColor": ["blueBright"],
+      "labelColor": ["blue"],
       "format": ["level", "id", "fileName", "timeDiffInit",  "timeDiffScope", "just:-", "scope", "message"]
     },
 
@@ -134,7 +134,7 @@
     },
 
     "timeDiffScope": {
-      "color": [ "blueBright" ],
+      "color": [ "blue" ],
       "defaultReturn": "0ms",
       "minimumWidth": 8,
       "alignment": "right"

--- a/packages/koa-signal/src/koa-signal.print-all.js
+++ b/packages/koa-signal/src/koa-signal.print-all.js
@@ -1,4 +1,4 @@
-import { dim } from 'chalk'
+import { dim } from 'picocolors'
 import Signal from './koa-signal.js'
 const signal = new Signal({ levels: {json: { format: [ 'json' ] }, rawJson: { format: ['raw-json']}}})
 


### PR DESCRIPTION
Replacing chalk with [picocolors](https://www.npmjs.com/package/picocolors) which claims to be faster and smaller than chalk ([benchmark](https://github.com/alexeyraspopov/picocolors#benchmarks)).

I'm having problems with building an app with vite which uses koa-signal, where the errors point to chalk and ansi-styles (which is used by chalk).

After spending some time trying to pin chalk to a different version without any success, I thought replacing chalk with a newer (and smaller) alternative would be a better thing to do - and it was 3 majors behind anyway.

With these changes my build works fine now 🎉 

