### PR TITLE
Update Node version to LTS 18.16

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: '2.0'
 services:
   koa-core:
-    image: node:10-alpine
+    image: node:18.16-alpine
     ports:
       - "3000:3000"
     networks:


### PR DESCRIPTION
Node 14 is EOL 30th of April 2023. This updates references to Node images < 14 to the LTS

[_Created by Sourcegraph batch change `rvu/node-14-eol`._](https://rvu.sourcegraph.com/organizations/rvu/batch-changes/node-14-eol)