### PR TITLE
🎾 upgrade koa to 2.15.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can see which version of node `koa-core` supports by looking in [.nvmrc](./.
 
 <!-- DO NOT REMOVE - This is generated documentation  -->
 <!-- [doc-list-packages-internal:start] -->
-<!-- Generated Thu Oct 19 2023 09:45:11 GMT+0100 (British Summer Time) -->
+<!-- Generated Thu Feb 20 2025 10:37:02 GMT+0000 (Greenwich Mean Time) -->
 | Package | Version | Dependencies | Description |
 |--|--|--|--|
 | [`@uswitch/koa-access`](https://www.npmjs.com/package/@uswitch/koa-access) | [![npm](https://img.shields.io/npm/v/@uswitch/koa-access.svg?maxAge=2592000)](https://www.npmjs.com/package/@uswitch/koa-access) | [![Dependency Status](https://david-dm.org/@uswitch/koa-access.svg?path=packages/@uswitch/koa-access)](https://david-dm.org/@uswitch/koa-access?path=packages/@uswitch/koa-access) | 👌 A Koa middleware for logging JSON access logs consistently, similar to morgan |
@@ -99,10 +99,10 @@ You can see which version of node `koa-core` supports by looking in [.nvmrc](./.
 #### `koa` packages
 <!-- DO NOT REMOVE - This is generated documentation  -->
 <!-- [doc-list-packages:start] -->
-<!-- Generated Thu Oct 19 2023 09:45:10 GMT+0100 (British Summer Time) -->
+<!-- Generated Thu Feb 20 2025 10:37:01 GMT+0000 (Greenwich Mean Time) -->
 | Package | Version | Latest |
 |--|--|--|
-| [`koa`](https://www.npmjs.com/package/koa) | `^2.6.2` | [![npm](https://img.shields.io/npm/v/koa.svg?maxAge=2592000)](https://www.npmjs.com/package/koa) |
+| [`koa`](https://www.npmjs.com/package/koa) | `^2.15.4` | [![npm](https://img.shields.io/npm/v/koa.svg?maxAge=2592000)](https://www.npmjs.com/package/koa) |
 | [`koa-bodyparser`](https://www.npmjs.com/package/koa-bodyparser) | `^4.2.1` | [![npm](https://img.shields.io/npm/v/koa-bodyparser.svg?maxAge=2592000)](https://www.npmjs.com/package/koa-bodyparser) |
 | [`koa-compose`](https://www.npmjs.com/package/koa-compose) | `^4.1.0` | [![npm](https://img.shields.io/npm/v/koa-compose.svg?maxAge=2592000)](https://www.npmjs.com/package/koa-compose) |
 | [`koa-helmet`](https://www.npmjs.com/package/koa-helmet) | `^4.0.0` | [![npm](https://img.shields.io/npm/v/koa-helmet.svg?maxAge=2592000)](https://www.npmjs.com/package/koa-helmet) |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You can see which version of node `koa-core` supports by looking in [.nvmrc](./.
 
 <!-- DO NOT REMOVE - This is generated documentation  -->
 <!-- [doc-list-packages-internal:start] -->
-<!-- Generated Thu Feb 20 2025 10:37:02 GMT+0000 (Greenwich Mean Time) -->
+<!-- Generated Thu Feb 20 2025 10:37:23 GMT+0000 (Greenwich Mean Time) -->
 | Package | Version | Dependencies | Description |
 |--|--|--|--|
 | [`@uswitch/koa-access`](https://www.npmjs.com/package/@uswitch/koa-access) | [![npm](https://img.shields.io/npm/v/@uswitch/koa-access.svg?maxAge=2592000)](https://www.npmjs.com/package/@uswitch/koa-access) | [![Dependency Status](https://david-dm.org/@uswitch/koa-access.svg?path=packages/@uswitch/koa-access)](https://david-dm.org/@uswitch/koa-access?path=packages/@uswitch/koa-access) | 👌 A Koa middleware for logging JSON access logs consistently, similar to morgan |
@@ -99,7 +99,7 @@ You can see which version of node `koa-core` supports by looking in [.nvmrc](./.
 #### `koa` packages
 <!-- DO NOT REMOVE - This is generated documentation  -->
 <!-- [doc-list-packages:start] -->
-<!-- Generated Thu Feb 20 2025 10:37:01 GMT+0000 (Greenwich Mean Time) -->
+<!-- Generated Thu Feb 20 2025 10:37:23 GMT+0000 (Greenwich Mean Time) -->
 | Package | Version | Latest |
 |--|--|--|
 | [`koa`](https://www.npmjs.com/package/koa) | `^2.15.4` | [![npm](https://img.shields.io/npm/v/koa.svg?maxAge=2592000)](https://www.npmjs.com/package/koa) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-core",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@uswitch/koa-core",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@uswitch/koa-core",
-      "version": "2.0.5",
+      "version": "2.0.6",
       "license": "MIT",
       "dependencies": {
         "@uswitch/koa-access": "^2.9.11",
@@ -17,7 +17,7 @@
         "@uswitch/koa-timeout": "^1.6.11",
         "@uswitch/koa-tracer": "^1.7.11",
         "@uswitch/koa-zipkin": "^1.11.13",
-        "koa": "^2.6.2",
+        "koa": "^2.15.4",
         "koa-bodyparser": "^4.2.1",
         "koa-compose": "^4.1.0",
         "koa-helmet": "^4.0.0",
@@ -6459,9 +6459,9 @@
       "dev": true
     },
     "node_modules/cookies": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.8.0.tgz",
-      "integrity": "sha512-8aPsApQfebXnuI+537McwYsDtjVxGm8gTIzQI3FDW6t5t/DAhERxtnbEPN/8RX+uZthoz4eCOgloXaE5cYyNow==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/cookies/-/cookies-0.9.1.tgz",
+      "integrity": "sha512-TG2hpqe4ELx54QER/S3HQ9SRVnQnGBtKUz5bLQWtYAQ+o6GpgMs6sYUvaiJjVxb+UXwhRhAEP3m7LbsIZ77Hmw==",
       "dependencies": {
         "depd": "~2.0.0",
         "keygrip": "~1.1.0"
@@ -10063,15 +10063,15 @@
       }
     },
     "node_modules/koa": {
-      "version": "2.14.2",
-      "resolved": "https://registry.npmjs.org/koa/-/koa-2.14.2.tgz",
-      "integrity": "sha512-VFI2bpJaodz6P7x2uyLiX6RLYpZmOJqNmoCst/Yyd7hQlszyPwG/I9CQJ63nOtKSxpt5M7NH67V6nJL2BwCl7g==",
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/koa/-/koa-2.15.4.tgz",
+      "integrity": "sha512-7fNBIdrU2PEgLljXoPWoyY4r1e+ToWCmzS/wwMPbUNs7X+5MMET1ObhJBlUkF5uZG9B6QhM2zS1TsH6adegkiQ==",
       "dependencies": {
         "accepts": "^1.3.5",
         "cache-content-type": "^1.0.0",
         "content-disposition": "~0.5.2",
         "content-type": "^1.0.4",
-        "cookies": "~0.8.0",
+        "cookies": "~0.9.0",
         "debug": "^4.3.2",
         "delegates": "^1.0.0",
         "depd": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "lerna": "^3.22.1",
     "npm-watch": "^0.3.0"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf",
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58",
   "volta": {
     "node": "18.17.1"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-core",
-  "version": "2.0.6",
+  "version": "2.0.7",
   "description": "🎾 An example project showing the user of all core `@uswitch/koa` libraries",
   "main": "koa-core.js",
   "scripts": {
@@ -39,14 +39,14 @@
     "example": "__example__/*"
   },
   "dependencies": {
-    "@uswitch/koa-access": "^2.9.11",
-    "@uswitch/koa-cookie": "^1.4.11",
-    "@uswitch/koa-core": "^2.0.3",
-    "@uswitch/koa-prometheus": "^1.0.3",
-    "@uswitch/koa-signal": "^1.10.11",
-    "@uswitch/koa-timeout": "^1.6.11",
-    "@uswitch/koa-tracer": "^1.7.11",
-    "@uswitch/koa-zipkin": "^1.11.13",
+    "@uswitch/koa-access": "^2.9.12",
+    "@uswitch/koa-cookie": "^1.4.12",
+    "@uswitch/koa-core": "^2.0.7",
+    "@uswitch/koa-prometheus": "^1.0.4",
+    "@uswitch/koa-signal": "^1.10.12",
+    "@uswitch/koa-timeout": "^1.6.12",
+    "@uswitch/koa-tracer": "^1.7.12",
+    "@uswitch/koa-zipkin": "^1.11.14",
     "koa": "^2.15.4",
     "koa-bodyparser": "^4.2.1",
     "koa-compose": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@uswitch/koa-timeout": "^1.6.11",
     "@uswitch/koa-tracer": "^1.7.11",
     "@uswitch/koa-zipkin": "^1.11.13",
-    "koa": "^2.6.2",
+    "koa": "^2.15.4",
     "koa-bodyparser": "^4.2.1",
     "koa-compose": "^4.1.0",
     "koa-helmet": "^4.0.0",

--- a/packages/koa-access/package-lock.json
+++ b/packages/koa-access/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-access",
-	"version": "2.9.11",
+	"version": "2.9.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-access/package.json
+++ b/packages/koa-access/package.json
@@ -47,5 +47,5 @@
   "dependencies": {
     "on-finished": "^2.4.1"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-access/package.json
+++ b/packages/koa-access/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-access",
-  "version": "2.9.11",
+  "version": "2.9.12",
   "license": "MIT",
   "description": "👌 A Koa middleware for logging JSON access logs consistently, similar to morgan",
   "main": "build/koa-access.js",

--- a/packages/koa-cookie/package-lock.json
+++ b/packages/koa-cookie/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-cookie",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/packages/koa-cookie/package.json
+++ b/packages/koa-cookie/package.json
@@ -16,5 +16,5 @@
     "directory": "packages/koa-cookie"
   },
   "license": "ISC",
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-cookie/package.json
+++ b/packages/koa-cookie/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-cookie",
-  "version": "1.4.11",
+  "version": "1.4.12",
   "description": "🍪 Koa cookie parser middleware",
   "main": "index.js",
   "scripts": {

--- a/packages/koa-prometheus/package-lock.json
+++ b/packages/koa-prometheus/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-prometheus",
-	"version": "1.0.2",
+	"version": "1.0.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-prometheus/package.json
+++ b/packages/koa-prometheus/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-prometheus",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "🌡️ A configurable Prometheus data collector with Koa middleware",
   "main": "build/koa-prometheus.js",
   "scripts": {

--- a/packages/koa-prometheus/package.json
+++ b/packages/koa-prometheus/package.json
@@ -48,5 +48,5 @@
     "npm-run-all": "^4.1.3",
     "npm-watch": "^0.11.0"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-signal/package-lock.json
+++ b/packages/koa-signal/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-signal",
-	"version": "1.10.11",
+	"version": "1.10.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-signal/package.json
+++ b/packages/koa-signal/package.json
@@ -57,5 +57,5 @@
     "npm-run-all": "^4.1.3",
     "npm-watch": "^0.11.0"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-signal/package.json
+++ b/packages/koa-signal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-signal",
-  "version": "1.10.11",
+  "version": "1.10.12",
   "description": "🚦 Hackable and configurable output rendering for loggers",
   "main": "build/koa-signal.js",
   "scripts": {

--- a/packages/koa-timeout/package-lock.json
+++ b/packages/koa-timeout/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-timeout",
-	"version": "1.6.11",
+	"version": "1.6.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-timeout/package.json
+++ b/packages/koa-timeout/package.json
@@ -30,5 +30,5 @@
     "@babel/preset-env": "^7.22.15",
     "del-cli": "^5.1.0"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-timeout/package.json
+++ b/packages/koa-timeout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-timeout",
-  "version": "1.6.11",
+  "version": "1.6.12",
   "description": "⏰ A Koa middleware to handle timeouts correctly",
   "main": "build/koa-timeout.js",
   "scripts": {

--- a/packages/koa-tracer/package-lock.json
+++ b/packages/koa-tracer/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-tracer",
-	"version": "1.7.11",
+	"version": "1.7.12",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-tracer/package.json
+++ b/packages/koa-tracer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-tracer",
-  "version": "1.7.11",
+  "version": "1.7.12",
   "license": "MIT",
   "author": "Dom Charlesworth <dominic.charlesworth@uswitch.com>",
   "description": "🕵️‍♀️ A koa.js middleware to add namespaced tracing throughout a requests lifecycle",

--- a/packages/koa-tracer/package.json
+++ b/packages/koa-tracer/package.json
@@ -42,5 +42,5 @@
     "eslint-plugin-standard": "^3.0.1",
     "jest": "^29.6.4"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-zipkin/package-lock.json
+++ b/packages/koa-zipkin/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@uswitch/koa-zipkin",
-	"version": "1.11.13",
+	"version": "1.11.14",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {

--- a/packages/koa-zipkin/package.json
+++ b/packages/koa-zipkin/package.json
@@ -49,5 +49,5 @@
     "zipkin-instrumentation-koa": "^0.22.0",
     "zipkin-transport-http": "^0.22.0"
   },
-  "gitHead": "094e57d5061356d238b7082e8b4c904ed51c4abf"
+  "gitHead": "a88a0aa8366e6aadb5a7f1e1d6b6f4afe2915b58"
 }

--- a/packages/koa-zipkin/package.json
+++ b/packages/koa-zipkin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uswitch/koa-zipkin",
-  "version": "1.11.13",
+  "version": "1.11.14",
   "license": "MIT",
   "author": "Dom Charlesworth <dominic.charlesworth@uswitch.com>",
   "description": "🕵️‍♀️ A koa.js middleware to add Zipkin tracing to requests",


### PR DESCRIPTION
- There is a critical ReDoS vulnerability in Koa which requires a bump to 2.15.4 or greater
- https://security.snyk.io/vuln/SNYK-JS-KOA-8720152